### PR TITLE
feat(068): recordings (site_id,uri) + (site_id,upload_time) sort indexes

### DIFF
--- a/init/068-add-recordings-site-sort-indexes.sql
+++ b/init/068-add-recordings-site-sort-indexes.sql
@@ -1,24 +1,41 @@
--- Composite indexes to support server-side sorting of the project recordings
--- list (audiodata/recordings) by Filename and Uploaded, scoped to a project's
+-- Support fast server-side sorting of the project recordings list
+-- (audiodata/recordings) by Filename and Uploaded, scoped to a project's
 -- sites (WHERE site_id IN (...)).
 --
 -- Why: the list query first selects a page of recording_id in the requested
 -- order. Without a (site_id, <col>) composite, the optimizer falls back to a
--- single-column index (uri / upload_time) and full-scans the ~273M-row table,
--- tripping max_statement_time -> the list comes back empty ("0 Recordings").
--- A site-leading composite lets the project-scoped sort stay fast (~50-80ms).
+-- single-column index and full-scans the ~273M-row recordings table, tripping
+-- max_statement_time -> the list comes back empty ("0 Recordings"). A
+-- site-leading composite keeps the project-scoped sort fast (~50-80ms).
 --
 -- `site` and `datetime` sorts are already covered by the existing
--- `recordings_site_datetime_idx (site_id, datetime)`. `recorder` is not made
--- sortable (no composite, and the displayed value lives in meta JSON).
+-- `recordings_site_datetime_idx (site_id, datetime)`.
 --
--- Applied online to production on 2026-06-19 with
---   ALGORITHM=INPLACE, LOCK=NONE
--- (recordings_site_uri_idx ~27m, recordings_site_upload_time_idx ~16m).
--- IF NOT EXISTS makes re-running safe where they already exist.
+-- Filename: the value shown in the UI's Filename column is the recording's
+-- meta.filename (e.g. "20220202_043000.WAV"), NOT the uri basename (an opaque
+-- UUID). meta is a JSON TEXT blob, so we expose it as a VIRTUAL generated
+-- column and index that. VIRTUAL (not STORED/PERSISTENT) so the column can be
+-- added INSTANT (no table rebuild on 273M rows) and stays in sync with meta
+-- automatically -- the index materializes the extracted value.
+--
+-- Uploaded: index (site_id, upload_time).
+--
+-- `recorder` is intentionally NOT made sortable (no composite; value also
+-- lives in meta).
+--
+-- Applied online to rfcx-local production on 2026-06-19:
+--   - ADD COLUMN filename ... VIRTUAL          -> ALGORITHM=INSTANT (instant)
+--   - ADD INDEX recordings_site_filename_idx   -> INPLACE/LOCK=NONE
+--   - ADD INDEX recordings_site_upload_time_idx-> INPLACE/LOCK=NONE
+-- IF NOT EXISTS keeps re-runs safe where they already exist.
 
 ALTER TABLE `arbimon2`.`recordings`
-  ADD INDEX IF NOT EXISTS `recordings_site_uri_idx` (`site_id`, `uri`),
+  ADD COLUMN IF NOT EXISTS `filename` VARCHAR(255)
+    AS (JSON_VALUE(`meta`, '$.filename')) VIRTUAL,
+  ALGORITHM=INSTANT;
+
+ALTER TABLE `arbimon2`.`recordings`
+  ADD INDEX IF NOT EXISTS `recordings_site_filename_idx` (`site_id`, `filename`),
   ALGORITHM=INPLACE, LOCK=NONE;
 
 ALTER TABLE `arbimon2`.`recordings`

--- a/init/068-add-recordings-site-sort-indexes.sql
+++ b/init/068-add-recordings-site-sort-indexes.sql
@@ -1,0 +1,26 @@
+-- Composite indexes to support server-side sorting of the project recordings
+-- list (audiodata/recordings) by Filename and Uploaded, scoped to a project's
+-- sites (WHERE site_id IN (...)).
+--
+-- Why: the list query first selects a page of recording_id in the requested
+-- order. Without a (site_id, <col>) composite, the optimizer falls back to a
+-- single-column index (uri / upload_time) and full-scans the ~273M-row table,
+-- tripping max_statement_time -> the list comes back empty ("0 Recordings").
+-- A site-leading composite lets the project-scoped sort stay fast (~50-80ms).
+--
+-- `site` and `datetime` sorts are already covered by the existing
+-- `recordings_site_datetime_idx (site_id, datetime)`. `recorder` is not made
+-- sortable (no composite, and the displayed value lives in meta JSON).
+--
+-- Applied online to production on 2026-06-19 with
+--   ALGORITHM=INPLACE, LOCK=NONE
+-- (recordings_site_uri_idx ~27m, recordings_site_upload_time_idx ~16m).
+-- IF NOT EXISTS makes re-running safe where they already exist.
+
+ALTER TABLE `arbimon2`.`recordings`
+  ADD INDEX IF NOT EXISTS `recordings_site_uri_idx` (`site_id`, `uri`),
+  ALGORITHM=INPLACE, LOCK=NONE;
+
+ALTER TABLE `arbimon2`.`recordings`
+  ADD INDEX IF NOT EXISTS `recordings_site_upload_time_idx` (`site_id`, `upload_time`),
+  ALGORITHM=INPLACE, LOCK=NONE;


### PR DESCRIPTION
Adds migration `init/068-add-recordings-site-sort-indexes.sql`.

(Branch name says 060 but the file is numbered **068** — 060–067 are already taken by in-flight drop-table cleanup branches, so I bumped to the next free number.)

## What
Two composite indexes on `arbimon2.recordings`:
- `recordings_site_uri_idx (site_id, uri)`
- `recordings_site_upload_time_idx (site_id, upload_time)`

## Why
Supports the new **server-side sorting of the project recordings list** (audiodata/recordings) by **Filename** (`uri`) and **Uploaded** (`upload_time`), scoped to a project (`WHERE site_id IN (...)`).

Without a `(site_id, <col>)` composite, MariaDB picks a single-column index (`uri`/`upload_time`) and full-scans the ~273M-row `recordings` table, tripping `max_statement_time` → the list query returns empty → **"0 Recordings"** in the UI. With the composite, the project-scoped sort is **~50–80ms**.

`site`/`datetime` sorts already use the existing `recordings_site_datetime_idx (site_id, datetime)`. `recorder` is intentionally not made sortable (no composite; displayed value lives in `meta` JSON).

## Applied to production
Already applied **online** to rfcx-local prod on 2026-06-19 with `ALGORITHM=INPLACE, LOCK=NONE` (uri ~27m, upload_time ~16m; site stayed healthy throughout). `IF NOT EXISTS` makes the migration safe to re-run where the indexes already exist.

🤖 agent session (ms4).